### PR TITLE
fix: Avoid changing the URL of the service worker.

### DIFF
--- a/lib/jekyll-pwa-plugin.rb
+++ b/lib/jekyll-pwa-plugin.rb
@@ -14,7 +14,7 @@ class SWHelper
         sw_register_file.puts(
         <<-SCRIPT
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('#{@site.baseurl.to_s}/#{@sw_filename}?v=#{@site.time.to_i.to_s}').then(function(reg) {
+            navigator.serviceWorker.register('#{@site.baseurl.to_s}/#{@sw_filename}').then(function(reg) {
                 reg.onupdatefound = function() {
                     var installingWorker = reg.installing;
                     installingWorker.onstatechange = function() {
@@ -130,21 +130,7 @@ class SWHelper
     end
 
     def self.insert_sw_register_into_body(page)
-        page.output = page.output.sub('</body>',
-        <<-SCRIPT
-            <script>
-                window.onload = function () {
-                    var script = document.createElement('script');
-                    var firstScript = document.getElementsByTagName('script')[0];
-                    script.type = 'text/javascript';
-                    script.async = true;
-                    script.src = '#{page.site.baseurl.to_s}/sw-register.js?v=' + Date.now();
-                    firstScript.parentNode.insertBefore(script, firstScript);
-                };
-            </script>
-            </body>
-        SCRIPT
-        )
+        page.output = page.output.sub('</body>', "<script async src=\"#{page.site.baseurl.to_s}/sw-register.js\"></script></body>")
     end
 end
 


### PR DESCRIPTION
According to the official documentation[1], it's bad practice to change
the URL of the service worker. Also there's not really a point in having
time stamped URLs for the sw-register.js script. This also allows to
simplify the registration quite a bit, leading to less JavaScript to
parse and execute for the browser.

[1] https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle