### PR TITLE
Add enabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ plugins:
 Add the following configuration block to Jekyll's `_config.yml`:
 ```yaml
 pwa:
+  enabled: false # Optional
   sw_src_filepath: service-worker.js # Optional
   sw_dest_filename: service-worker.js # Optional
   dest_js_directory: assets/js # Required
@@ -72,6 +73,7 @@ pwa:
 
 Parameter                 | Description
 ----------                | ------------
+enabled                   | Determines whether a sw will be registered and written to disk. Useful to disable when you run into problems in your development environment. Default is `true`.
 sw_src_filepath           | Filepath of the source service worker. Defaults to `service-worker.js`
 sw_dest_filename          | Filename of the destination service worker. Defaults to `service-worker.js`
 dest_js_directory         | Directory of JS in `_site`. During the build process, some JS like workbox.js will be copied to this directory so that service worker can import them in runtime.

--- a/lib/jekyll-pwa-plugin.rb
+++ b/lib/jekyll-pwa-plugin.rb
@@ -151,22 +151,31 @@ end
 module Jekyll
 
     Hooks.register :pages, :post_render do |page|
+      enabled = page.site.config.dig('pwa', 'enabled')
+      if enabled
         # append <script> for sw-register.js in <body>
         SWHelper.insert_sw_register_into_body(page)
+      end
     end
 
     Hooks.register :documents, :post_render do |document|
+      enabled = document.site.config.dig('pwa', 'enabled')
+      if enabled
         # append <script> for sw-register.js in <body>
         SWHelper.insert_sw_register_into_body(document)
+      end
     end
 
     Hooks.register :site, :post_write do |site|
+      enabled = site.config.dig('pwa', 'enabled')
+      if enabled
         pwa_config = site.config['pwa'] || {}
         sw_helper = SWHelper.new(site, pwa_config)
 
         sw_helper.write_sw_register()
         sw_helper.generate_workbox_precache()
         sw_helper.write_sw()
+      end
     end
 
 end

--- a/lib/jekyll-pwa-plugin.rb
+++ b/lib/jekyll-pwa-plugin.rb
@@ -151,7 +151,7 @@ end
 module Jekyll
 
     Hooks.register :pages, :post_render do |page|
-      enabled = page.site.config.dig('pwa', 'enabled')
+      enabled = (page.site.config.dig('pwa', 'enabled') != false)
       if enabled
         # append <script> for sw-register.js in <body>
         SWHelper.insert_sw_register_into_body(page)
@@ -159,7 +159,7 @@ module Jekyll
     end
 
     Hooks.register :documents, :post_render do |document|
-      enabled = document.site.config.dig('pwa', 'enabled')
+      enabled = (page.site.config.dig('pwa', 'enabled') != false)
       if enabled
         # append <script> for sw-register.js in <body>
         SWHelper.insert_sw_register_into_body(document)
@@ -167,7 +167,7 @@ module Jekyll
     end
 
     Hooks.register :site, :post_write do |site|
-      enabled = site.config.dig('pwa', 'enabled')
+      enabled = (page.site.config.dig('pwa', 'enabled') != false)
       if enabled
         pwa_config = site.config['pwa'] || {}
         sw_helper = SWHelper.new(site, pwa_config)


### PR DESCRIPTION
To optionally disable sw registering in development, I've added a `enabled` flag for the config. Thought that'd be a good idea.